### PR TITLE
Fixed login error

### DIFF
--- a/react-locate-contractor/src/App.tsx
+++ b/react-locate-contractor/src/App.tsx
@@ -24,8 +24,8 @@ const App = () => {
   };
 
   const restoreOriginalUri = async (_oktaAuth: any, originalUri: any) => {
-    history.replace(toRelativeUrl(originalUri || '', window.location.origin));
-  };
+    history = (toRelativeUrl(originalUri, window.location.origin));
+  }
 
 
   return (

--- a/react-locate-contractor/src/config.tsx
+++ b/react-locate-contractor/src/config.tsx
@@ -3,12 +3,14 @@ export default {
         issuer: 'https://dev-81535986.okta.com/oauth2/default',
         clientId: '0oa5se2c6gLXwYT2S5d7',
         scopes: ['openid', 'profile', 'email'],
-        redirectUri: `https://yellow-sea-0fa5a340f.1.azurestaticapps.net/login/callback`
+        // redirectUri: `https://yellow-sea-0fa5a340f.1.azurestaticapps.net/login/callback`
+        redirectUri: `http://localhost:3000/login/callback`
     },
     widget: {
         issuer: 'https://dev-81535986.okta.com/oauth2/default',
         clientId: '0oa5se2c6gLXwYT2S5d7',
-        redirectUri: `https://yellow-sea-0fa5a340f.1.azurestaticapps.net/login/callback`,
+        // redirectUri: `https://yellow-sea-0fa5a340f.1.azurestaticapps.net/login/callback`,
+        redirectUri: `http://localhost:3000/login/callback`,
         scopes: ['openid', 'profile', 'email'],
         useInteractionCodeFlow: false
     }

--- a/react-locate-contractor/src/config.tsx
+++ b/react-locate-contractor/src/config.tsx
@@ -3,14 +3,14 @@ export default {
         issuer: 'https://dev-81535986.okta.com/oauth2/default',
         clientId: '0oa5se2c6gLXwYT2S5d7',
         scopes: ['openid', 'profile', 'email'],
-        // redirectUri: `https://yellow-sea-0fa5a340f.1.azurestaticapps.net/login/callback`
-        redirectUri: `http://localhost:3000/login/callback`
+        redirectUri: `https://yellow-sea-0fa5a340f.1.azurestaticapps.net/login/callback`
+        // redirectUri: `http://localhost:3000/login/callback`
     },
     widget: {
         issuer: 'https://dev-81535986.okta.com/oauth2/default',
         clientId: '0oa5se2c6gLXwYT2S5d7',
-        // redirectUri: `https://yellow-sea-0fa5a340f.1.azurestaticapps.net/login/callback`,
-        redirectUri: `http://localhost:3000/login/callback`,
+        redirectUri: `https://yellow-sea-0fa5a340f.1.azurestaticapps.net/login/callback`,
+        // redirectUri: `http://localhost:3000/login/callback`,
         scopes: ['openid', 'profile', 'email'],
         useInteractionCodeFlow: false
     }


### PR DESCRIPTION
This PR addresses the error that was thrown after a user logged in through okta.

Changes made:
Code supplied by okta used a keyword "replace" that had no definition. The keyword was replaced with an equal sign. 